### PR TITLE
Show scores and lives for both players when playing multiplayer.

### DIFF
--- a/src/main/java/controller/LevelController.java
+++ b/src/main/java/controller/LevelController.java
@@ -95,11 +95,12 @@ public class LevelController implements Observer {
                 mainController.addListeners(KeyEvent.KEY_RELEASED, pauseKeyEventHandlerRelease);
 
                 if (players.size() > 0 && players.get(0) != null) {
-                    mainController.showLives(players.get(0).getLives());
-                    mainController.showScore(players.get(0).getScore());
+                    Player player = players.get(0);
+                    mainController.showLives(player.getLives(), player.getPlayerNumber());
+                    mainController.showScore(player.getScore(), player.getPlayerNumber());
                 } else {
-                    mainController.showLives(0);
-                    mainController.showScore(0);
+                    mainController.showLives(0, 0);
+                    mainController.showScore(0, 0);
                 }
                 gameLoop.start();
             }
@@ -519,8 +520,8 @@ public class LevelController implements Observer {
                 gameOver();
             } else {
                 Logger.log(String.format("Score: %d", p.getScore()));
-                mainController.showScore(p.getScore());
-                mainController.showLives(p.getLives());
+                mainController.showScore(p.getScore(), p.getPlayerNumber());
+                mainController.showLives(p.getLives(), p.getPlayerNumber());
             }
         }
     }

--- a/src/main/java/controller/MainController.java
+++ b/src/main/java/controller/MainController.java
@@ -30,6 +30,10 @@ public class MainController implements Initializable {
     @FXML private Pane playFieldLayer;
     @FXML private Text livesText;
     @FXML private Text scoreText;
+    @FXML private Text livesTextPlayer1;
+    @FXML private Text livesTextPlayer2;
+    @FXML private Text scoreTextPlayer1;
+    @FXML private Text scoreTextPlayer2;
 
     private ScreenController screenController;
 
@@ -66,20 +70,46 @@ public class MainController implements Initializable {
      * Show lives in the top bar.
      *
      * @param lives The number of lives.
+     * @param playerNumber The number of the player (used for multiplayer).
      */
-    public void showLives(int lives) {
+    public void showLives(int lives, int playerNumber) {
+
         livesText.setVisible(true);
-        livesText.setText(String.format("Lives: %d", lives));
+
+        if (playerNumber == 1) {
+            livesTextPlayer1.setVisible(true);
+
+            if (StartController.getLimitOfPlayers() == 1) {
+                livesTextPlayer1.setText(String.format("%d", lives));
+            } else {
+                livesTextPlayer1.setText(String.format("%d (Player 1)", lives));
+            }
+        }
+
+        if (playerNumber == 2) {
+            livesTextPlayer2.setVisible(true);
+            livesTextPlayer2.setText(String.format("%d (Player 2)", lives));
+        }
     }
 
     /**
      * This function show the score of the player.
      *
      * @param score The score (number of points).
+     * @param playerNumber The number of the player (used for multiplayer).
      */
-    public void showScore(int score) {
+    public void showScore(int score, int playerNumber) {
         scoreText.setVisible(true);
-        scoreText.setText(String.format("Score: %d", score));
+
+        if (playerNumber == 1) {
+            scoreTextPlayer1.setVisible(true);
+            scoreTextPlayer1.setText(String.format("%d", score));
+        }
+
+        if (playerNumber == 2) {
+            scoreTextPlayer2.setVisible(true);
+            scoreTextPlayer2.setText(String.format("%d", score));
+        }
     }
 
     /**

--- a/src/main/java/controller/MainController.java
+++ b/src/main/java/controller/MainController.java
@@ -82,13 +82,12 @@ public class MainController implements Initializable {
             if (StartController.getLimitOfPlayers() == 1) {
                 livesTextPlayer1.setText(String.format("%d", lives));
             } else {
-                livesTextPlayer1.setText(String.format("%d (Player 1)", lives));
+                livesTextPlayer1.setText(String.format("P1: %d", lives));
             }
-        }
 
-        if (playerNumber == 2) {
+        } else if (playerNumber == 2) {
             livesTextPlayer2.setVisible(true);
-            livesTextPlayer2.setText(String.format("%d (Player 2)", lives));
+            livesTextPlayer2.setText(String.format("P2: %d", lives));
         }
     }
 
@@ -104,9 +103,7 @@ public class MainController implements Initializable {
         if (playerNumber == 1) {
             scoreTextPlayer1.setVisible(true);
             scoreTextPlayer1.setText(String.format("%d", score));
-        }
-
-        if (playerNumber == 2) {
+        } else if (playerNumber == 2) {
             scoreTextPlayer2.setVisible(true);
             scoreTextPlayer2.setText(String.format("%d", score));
         }

--- a/src/main/resources/level.fxml
+++ b/src/main/resources/level.fxml
@@ -1,42 +1,86 @@
 <?xml version="1.0" encoding="UTF-8"?>
-        
+
+<?import javafx.scene.paint.*?>
+<?import javafx.geometry.*?>
+<?import java.lang.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.*?>
 
+<AnchorPane stylesheets="@stylesheet.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="controller.MainController">
+    <children>
+        <VBox prefHeight="200.0" prefWidth="100.0">
+            <children>
+                <StackPane fx:id="root" layoutX="-20.0" visible="true">
+                    <children>
 
-<AnchorPane stylesheets="@stylesheet.css" xmlns="http://javafx.com/javafx/8.0.40"
-            xmlns:fx="http://javafx.com/fxml/1" fx:controller="controller.MainController">
-   <VBox prefHeight="200.0" prefWidth="100.0">
-      <GridPane fx:id="gridPane">
-         <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"/>
-            <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" minWidth="10.0"
-                               prefWidth="100.0"/>
-         </columnConstraints>
-         <rowConstraints>
-            <RowConstraints minHeight="30.0" vgrow="ALWAYS"/>
-         </rowConstraints>
-         <Text fx:id="livesText" fill="WHITE" strokeType="OUTSIDE" strokeWidth="0.0"
-               text="Lives: #" visible="false">
-            <font>
-               <Font size="30.0"/>
-            </font>
-         </Text>
-         <Text fx:id="scoreText" fill="WHITE" strokeType="OUTSIDE" strokeWidth="0.0"
-               text="Score: #" visible="false" GridPane.columnIndex="1"/>
-      </GridPane>
-      <StackPane fx:id="root" visible="true">
+                        <Text fx:id="startMessage" styleClass="levelMessage" text="Click anywhere to start"/>
 
-         <Text fx:id="startMessage" styleClass="levelMessage" text="Click anywhere to start"/>
+                        <VBox fx:id="pauseVBox" styleClass="pauseVBox" visible="false">
+                            <children>
+                                <Text fx:id="pauseMessage" styleClass="levelMessage" text="Game paused"
+                                      visible="false"/>
+                                <Text fx:id="pauseMessageSub" styleClass="levelMessageSub" text="Press 'p' to continue"
+                                      visible="false"/>
+                            </children>
+                        </VBox>
+                        <Pane fx:id="playFieldLayer"/>
+                    </children>
+                </StackPane>
+            </children>
+        </VBox>
+        <GridPane fx:id="gridPane" prefHeight="36.0" prefWidth="832.0" style="-fx-background-color: transparent;">
+            <columnConstraints>
+                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"/>
+                <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0"/>
+            </columnConstraints>
+            <rowConstraints>
+                <RowConstraints minHeight="30.0" vgrow="ALWAYS"/>
+                <RowConstraints minHeight="30.0" prefHeight="30.0" vgrow="ALWAYS"/>
+                <RowConstraints minHeight="30.0" prefHeight="30.0" vgrow="ALWAYS"/>
+            </rowConstraints>
+            <children>
+                <Text fx:id="livesText" fill="BLACK" strokeType="OUTSIDE" strokeWidth="0.0" text="Lives:"
+                      visible="false" GridPane.columnIndex="0" GridPane.rowIndex="0">
+                    <font>
+                        <Font size="30.0"/>
+                    </font>
+                    <GridPane.margin>
+                        <Insets left="32.0"/>
+                    </GridPane.margin>
+                </Text>
+                <Text fx:id="livesTextPlayer1" fill="WHITE" strokeType="OUTSIDE" strokeWidth="0.0" text="Player 1: #"
+                      visible="false" GridPane.columnIndex="0" GridPane.rowIndex="1">
+                    <GridPane.margin>
+                        <Insets left="32.0"/>
+                    </GridPane.margin>
+                </Text>
+                <Text fx:id="livesTextPlayer2" fill="WHITE" strokeType="OUTSIDE" strokeWidth="0.0" text="Player 2: #"
+                      visible="false" GridPane.columnIndex="0" GridPane.rowIndex="2">
+                    <GridPane.margin>
+                        <Insets left="32.0"/>
+                    </GridPane.margin>
+                </Text>
 
-         <VBox fx:id="pauseVBox" styleClass="pauseVBox" visible="false">
-            <Text fx:id="pauseMessage" styleClass="levelMessage" text="Game paused"
-                  visible="false"/>
-            <Text fx:id="pauseMessageSub" styleClass="levelMessageSub"
-                  text="Press 'p' to continue" visible="false"/>
-         </VBox>
-         <Pane fx:id="playFieldLayer"/>
-      </StackPane>
-   </VBox>
+                <Text fx:id="scoreText" fill="BLACK" strokeType="OUTSIDE" strokeWidth="0.0" text="Score:"
+                      visible="false" GridPane.columnIndex="1" GridPane.rowIndex="0">
+                    <GridPane.margin>
+                        <Insets right="32.0"/>
+                    </GridPane.margin>
+                </Text>
+                <Text fx:id="scoreTextPlayer1" fill="WHITE" strokeType="OUTSIDE" strokeWidth="0.0" text="test: #"
+                      visible="false" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                    <GridPane.margin>
+                        <Insets right="32.0"/>
+                    </GridPane.margin>
+                </Text>
+                <Text fx:id="scoreTextPlayer2" fill="WHITE" strokeType="OUTSIDE" strokeWidth="0.0" text="test: #"
+                      visible="false" GridPane.columnIndex="1" GridPane.rowIndex="2">
+                    <GridPane.margin>
+                        <Insets right="32.0"/>
+                    </GridPane.margin>
+                </Text>
+            </children>
+        </GridPane>
+    </children>
 </AnchorPane>
-


### PR DESCRIPTION
When playing multiplayer, show both the scores and lives for player 1 and 2. When playing singleplayer just show 1 score without annotation like "(Player 1)". Also fixed scores to be placed in the screen instead of in a bar above the screen. 
<feature
