### PR TITLE
Fixed music being enabled although preferences were to disable music

### DIFF
--- a/src/main/java/launcher/Launcher.java
+++ b/src/main/java/launcher/Launcher.java
@@ -83,7 +83,7 @@ public class Launcher extends Application {
      * @param themeName String with the relative path to the song.
      */
     public static void changeMusicSong(String themeName) {
-        if (mediaPlayer != null) {
+        if (Settings.getBoolean("PLAY_MUSIC", true) && mediaPlayer != null) {
             mediaPlayer.stop();
             setMusicSong(themeName);
             mediaPlayer.setCycleCount(MediaPlayer.INDEFINITE);


### PR DESCRIPTION
When the music was changed in-game, the preferences weren't taken into account. This meant that when the game decided to change the music (in case of boss-level for example), music was being played although the player disabled music in preferences. Fixes #291 
<bug
